### PR TITLE
Only record changes more than 2 lines apart

### DIFF
--- a/lib/last-cursor-position.coffee
+++ b/lib/last-cursor-position.coffee
@@ -13,6 +13,11 @@ module.exports =
          ed = atom.workspace.getActiveEditor()
          if ed? and @rewinding is false and @forwarding is false
             pos = ed.getCursorBufferPosition()
+            if @positionHistory.length
+              {editor: lastEd, position: lastPos} = @positionHistory[-1..-1][0]
+              if ed is lastEd and
+                    Math.abs(lastPos.serialize()[0] - pos.serialize()[0]) < 3
+                return
             @positionHistory.push({editor: ed, position: pos})
             #future positions get invalidated when cursor moves to a new position
             @positionFuture = []


### PR DESCRIPTION
I find your package very useful except that the increments are two small.  I want to just go to sections of code I have visited before, not move within a line.  This changed version only records new positions that are more than 2 lines apart.  I have been using it and it works well.
