### PR TITLE
Fix #17

### DIFF
--- a/lib/last-cursor-position.coffee
+++ b/lib/last-cursor-position.coffee
@@ -83,7 +83,9 @@ module.exports =
             pos.pane.activate()
          if pos.editor isnt atom.workspace.getActiveTextEditor()
             #console.log("--Activating editor " + pos.editor.id)
-            atom.workspace.getActivePane().activateItem(pos.editor)
+            activePane = atom.workspace.getActivePane()
+            editorIdx = activePane.getItems().indexOf(pos.editor)
+            activePane.activateItemAtIndex(editorIdx)
          #move cursor to last position and scroll to it
          #console.log("--Moving cursor to new position")
          atom.workspace.getActiveTextEditor().setCursorBufferPosition(pos.position, autoscroll:false)
@@ -112,7 +114,9 @@ module.exports =
             pos.pane.activate()
          if pos.editor isnt atom.workspace.getActiveTextEditor()
             #console.log("--Activating editor " + pos.editor.id)
-            atom.workspace.getActivePane().activateItem(pos.editor)
+            activePane = atom.workspace.getActivePane()
+            editorIdx = activePane.getItems().indexOf(pos.editor)
+            activePane.activateItemAtIndex(editorIdx)
          #move cursor to last position and scroll to it
          #console.log("--Moving cursor to new position")
          atom.workspace.getActiveTextEditor().setCursorBufferPosition(pos.position, autoscroll:false)


### PR DESCRIPTION
* Atom api for activateItem is bugged. There are many instances of plugins breaking due to this api
    * It seems that it tries to re-add the item every time we activate it
    * Current implementation of activateItemAtIndex does *not* try to add the item
    * Using this API seems to dodge the issue