### PR TITLE
provide third party a function to force add current cursor position to history

### DIFF
--- a/lib/last-cursor-position.coffee
+++ b/lib/last-cursor-position.coffee
@@ -58,6 +58,11 @@ module.exports =
       @disposables.add atom.commands.add 'atom-workspace',
         'last-cursor-position:previous': => @previous()
         'last-cursor-position:next': => @next()
+        'last-cursor-position:push': => @push()
+
+   push: ->
+      activeEd = atom.workspace.getActiveTextEditor()
+      @positionHistory.push({pane: atom.workspace.getActivePane(), editor: activeEd, position: activeEd.getCursorBufferPosition()})
 
    previous: ->
       #console.log("Previous called")


### PR DESCRIPTION
I have forked atom-ternjs. When jumping into js definition I would like to remember the current cursor position to jump back to. having this function allows me to set the current cursor position before jumping